### PR TITLE
Mouse is no longer moved on window activation

### DIFF
--- a/Console/MainFrame.cpp
+++ b/Console/MainFrame.cpp
@@ -796,16 +796,6 @@ void MainFrame::ShowHideWindow(ShowHideWidowAction action /*= ShowHideWidowActio
   {
     PostMessage(WM_ACTIVATEAPP, TRUE, 0);
 
-    POINT	cursorPos;
-    CRect	windowRect;
-
-    ::GetCursorPos(&cursorPos);
-    GetWindowRect(&windowRect);
-
-    if ((cursorPos.x < windowRect.left) || (cursorPos.x > windowRect.right)) cursorPos.x = windowRect.left + windowRect.Width()/2;
-    if ((cursorPos.y < windowRect.top) || (cursorPos.y > windowRect.bottom)) cursorPos.y = windowRect.top + windowRect.Height()/2;
-
-    ::SetCursorPos(cursorPos.x, cursorPos.y);
     ::SetForegroundWindow(m_hWnd);
   }
 


### PR DESCRIPTION
The mouse is no longer moved into the window bounds on window activation.

If this is actually a desired feature (obviously someone wrote the code to do it...), there should be an option to toggle this behavior, or it should read from the system's accessibility settings which define the behavior globally. However, in lieu of such an option (which I don't care to do myself), the functionality should default to the least intrusive option: not moving the mouse.