### PR TITLE
Add issue template for future issues

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,37 @@
+https://github.com/cbucher/console/wiki/How-to-Report-an-Issue
+
+Can you reproduce this issue in the original shell without using ConsoleZ?  
+If so then it is not a ConsoleZ issue. Please contact the shell or responsible program's owner instead.
+
+Before continuing please check to see if the issue occurs in the latest version (experimental, beta, or release) available here:
+https://github.com/cbucher/console/wiki/Downloads
+
+Lastly, please search for an extisting issue before opening a new one.
+
+If this is in fact a new issue in ConsoleZ then feel free to delete this message and proceed.
+
+Thank you!
+
+-----------
+
+### Expected Behavior
+What you expect to happen.
+
+### Actual Behavior
+What actually happens.
+
+### Steps to reproduce
+1. What steps consistently cause this behavior?
+2. What does someone need to do to recreate the issue?
+
+### Diagnostic Report
+```
+From within ConsoleZ select Help > Diagnose.
+This will open a file in Notepad with useful information.
+Please paste that information here or include that file.
+```
+
+### Crash Report
+When reporting a crash you must provide a crash dump.
+Instructions on how to generate one can be found here:
+https://github.com/cbucher/console/wiki/How-to-Report-an-Issue


### PR DESCRIPTION
This takes advantage of a [recently added](https://github.com/blog/2111-issue-and-pull-request-templates) GitHub feature to provide a template starting point for new issues.

Additional information is available here: https://help.github.com/articles/creating-an-issue-template-for-your-repository/

I tried to capture everything in the [wiki page](https://github.com/cbucher/console/wiki/How-to-Report-an-Issue), but please give it a read and I'll try to incorporate any feedback.