### PR TITLE
System environment variables no longer override local environment variables.

### DIFF
--- a/Console/ConsoleHandler.cpp
+++ b/Console/ConsoleHandler.cpp
@@ -1023,11 +1023,8 @@ bool ConsoleHandler::SearchText(CString& text, bool bNext, const COORD& coordCur
 void ConsoleHandler::UpdateCurrentUserEnvironmentBlock()
 {
 	void*	pEnvironment	= NULL;
-	HANDLE	hProcessToken	= NULL;
 
-	::OpenProcessToken(::GetCurrentProcess(), TOKEN_ALL_ACCESS, &hProcessToken);
-	::CreateEnvironmentBlock(&pEnvironment, hProcessToken, TRUE);
-	::CloseHandle(hProcessToken);
+	pEnvironment = GetEnvironmentStrings();
 
 	s_environmentBlock.reset(pEnvironment, ::DestroyEnvironmentBlock);
 }

--- a/Console/ConsoleHandler.cpp
+++ b/Console/ConsoleHandler.cpp
@@ -1022,11 +1022,11 @@ bool ConsoleHandler::SearchText(CString& text, bool bNext, const COORD& coordCur
 
 void ConsoleHandler::UpdateCurrentUserEnvironmentBlock()
 {
-	void*	pEnvironment	= NULL;
+	LPTCH 	pEnvironment = NULL;
 
 	pEnvironment = GetEnvironmentStrings();
 
-	s_environmentBlock.reset(pEnvironment, ::DestroyEnvironmentBlock);
+	s_environmentBlock.reset(pEnvironment, FreeEnvironmentStrings);
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch addresses:
https://github.com/cbucher/console/issues/345

The call to CreateEnvironmentBlock seems to be the issue.  Even though TRUE was passed in asking to inherit the environment from the parent process, that doesn't seem to mean what I think it means.  If the parent process and system environment have different values for an environment variable XYZ, then the system one is returned in this logic.  However, the GetEnvironmentStrings method seems to do the right thing.