### PR TITLE
Add ReleaseDC to prevent GDI leak

### DIFF
--- a/Console/DlgSettingsFont.cpp
+++ b/Console/DlgSettingsFont.cpp
@@ -119,8 +119,10 @@ LRESULT DlgSettingsFont::OnClickedBtnBrowseFont(WORD /*wNotifyCode*/, WORD /*wID
 	LOGFONT	lf;
 	::ZeroMemory(&lf, sizeof(LOGFONT));
 
+	HDC desktopDc = ::GetDC(NULL);
+
 	wcsncpy_s(lf.lfFaceName, _countof(lf.lfFaceName), LPCTSTR(m_strFontName), 32);
-	lf.lfHeight	= -MulDiv(m_fontSettings.dwSize, GetDeviceCaps(::GetDC(NULL), LOGPIXELSY), 72);
+	lf.lfHeight	= -MulDiv(m_fontSettings.dwSize, GetDeviceCaps(desktopDc, LOGPIXELSY), 72);
 	lf.lfWeight	= m_fontSettings.bBold ? FW_BOLD : FW_NORMAL;
 	lf.lfItalic	= m_fontSettings.bItalic ? 1 : 0;
 
@@ -130,7 +132,7 @@ LRESULT DlgSettingsFont::OnClickedBtnBrowseFont(WORD /*wNotifyCode*/, WORD /*wID
 	if (fontDlg.DoModal() == IDOK)
 	{
 		m_strFontName							= fontDlg.GetFaceName();
-		m_fontSettings.dwSize= static_cast<DWORD>(static_cast<double>(-fontDlg.m_lf.lfHeight*72)/static_cast<double>(GetDeviceCaps(::GetDC(NULL), LOGPIXELSY)) + 0.5);
+		m_fontSettings.dwSize= static_cast<DWORD>(static_cast<double>(-fontDlg.m_lf.lfHeight*72)/static_cast<double>(GetDeviceCaps(desktopDc, LOGPIXELSY)) + 0.5);
 		m_fontSettings.bBold					= fontDlg.IsBold() ? true : false;
 		m_fontSettings.bItalic					= fontDlg.IsItalic() ? true : false;
 

--- a/Console/MainFrame.cpp
+++ b/Console/MainFrame.cpp
@@ -623,7 +623,9 @@ LRESULT MainFrame::OnEraseBkgnd(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lPara
 	GetClientRect(clientRect);
 	CBrush backgroundBrush;
 	backgroundBrush.CreateSolidBrush(::GetSysColor(COLOR_WINDOW));
-	FillRect(GetDC(), clientRect, backgroundBrush);
+	HDC dc = GetDC();
+	FillRect(dc, clientRect, backgroundBrush);
+	ReleaseDC(dc);
 #endif
 
 	return 0;
@@ -3224,7 +3226,9 @@ LRESULT MainFrame::OnDiagnose(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl
 					FILE_ATTRIBUTE_NORMAL,
 					NULL));
 
-			Helpers::WriteLine(file.get(), std::wstring(L"System dpi ") + std::to_wstring(::GetDeviceCaps(GetDC(), LOGPIXELSY)));
+			HDC dc = GetDC();
+			Helpers::WriteLine(file.get(), std::wstring(L"System dpi ") + std::to_wstring(::GetDeviceCaps(dc, LOGPIXELSY)));
+			ReleaseDC(dc);
 			Helpers::WriteLine(file.get(), std::wstring(L"System metrics"));
 			Helpers::WriteLine(file.get(), std::wstring(L"  SM_CXSMICON        ") + std::to_wstring(::GetSystemMetrics(SM_CXSMICON)));
 			Helpers::WriteLine(file.get(), std::wstring(L"  SM_CYSMICON        ") + std::to_wstring(::GetSystemMetrics(SM_CYSMICON)));


### PR DESCRIPTION
The non-aero version is leaking GDI handles whenever it gained focus. Also opening the font settings dialog leaks GDI handle.