### PR TITLE
Removed reference to old XP "Apply Properties" window

### DIFF
--- a/help/html/language.html
+++ b/help/html/language.html
@@ -70,10 +70,8 @@
 				to something small (8 or 10 points). Small size will allow you 
 				bigger max ConsoleZ window size.
 				<br /><br />
-				Click OK. "Apply Properties" dialog will appear, select "Save 
-				properties for future windows with same title" and click OK. 
-				This will save Windows console settings for ConsoleZ. You can 
-				check your registry again, HKEY_CURRENT_USER\Console key. 
+				Click OK. This will save Windows console settings for ConsoleZ. 
+				You can check your registry again, HKEY_CURRENT_USER\Console key. 
 				There should be "ConsoleZ command window" subkey there again.
 			</li>
 			


### PR DESCRIPTION
As suggested in issue #461, I've removed the mention of the Apply Properties window.

Keep up the great work 👍 