### PR TITLE
Fixes compile error on cp936 locale

### DIFF
--- a/Console/ImageHandler.h
+++ b/Console/ImageHandler.h
@@ -59,7 +59,7 @@ public:
 		std::streamsize size = file.tellg();
 		file.seekg(0, std::ios::beg);
 
-		std::vector<char> content(size);
+		std::vector<char> content(static_cast<size_t>(size));
 		if( file.read(content.data(), size) )
 		{
 			return loadFromMemory(reinterpret_cast<const BYTE*>(content.data()), static_cast<DWORD>(content.size()));

--- a/Console/wtlaero.h
+++ b/Console/wtlaero.h
@@ -1,4 +1,4 @@
-// WtlAero.h
+﻿// WtlAero.h
 //
 // WTL::aero namespace: classes and functions supporting the Vista(r) Aero visual style
 //


### PR DESCRIPTION
Just change wtlaero.h header file encoding to UTF-8 BOM, and cast size to avoid warning on 32bit build.