### PR TITLE
Trim trailing spaces from column text selection

### DIFF
--- a/ConsoleHook/ConsoleHandler.cpp
+++ b/ConsoleHook/ConsoleHandler.cpp
@@ -1172,7 +1172,7 @@ void ConsoleHandler::CopyConsoleTextColumn(HANDLE hStdOut, std::unique_ptr<Clipb
 			clipboardDataPtr[clipboardDataIndex]->StartRow();
 
 		bool bWrap       = true;
-		bool bTrimSpaces = false;
+		bool bTrimSpaces = m_consoleCopyInfo->bTrimSpaces;
 
 		for (SHORT x = 0; x <= srBuffer.Right - srBuffer.Left; ++x)
 		{


### PR DESCRIPTION
Trim trailing spaces when selecting text columns