### PR TITLE
Fix environment variable sorting

### DIFF
--- a/Console/Helpers.h
+++ b/Console/Helpers.h
@@ -14,7 +14,11 @@ struct __case_insensitive_compare
 {
 	bool operator() (const std::wstring& a, const std::wstring& b) const
 	{
-		return (_wcsicmp(a.c_str( ), b.c_str()) < 0);
+		std::wstring a1 = a, b1 = b;
+
+		boost::to_upper(a1);
+		boost::to_upper(b1);
+		return (wcscmp(a1.c_str( ), b1.c_str()) < 0);
 	}
 };
 


### PR DESCRIPTION
This change makes ConsoleZ sort the environment variables the same way Windows does.

Windows sorts environment variables by up-casing the variable names to achieve case-insensitivity, while \_wcsicmp achieves case-insensitivity by lower-casing the string. Net difference is that an environment variable starting with '\_' would be sorted to the end (upper casing) vs. the beginning (lower casing).